### PR TITLE
Comparedb

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,12 +39,15 @@ Options for upgradedb
 ---------------------
 
 * ``--create`` - Compares database with current models in apps that are
-                 installed and outputs the sql for them so that you can easily
-                 pipe the contents to a migration.
+  installed and outputs the sql for them so that you can easily pipe the
+  contents to a migration.
 * ``--list`` - Lists all the scripts that will need to be executed.
 * ``--execute`` - Executes all the scripts that need to be executed.
 * ``--seed`` - Populates Migration model with scripts that have already been
-               applied to your database and effectively want to skip execution.
+  applied to your database and effectively want to skip execution. Provide a
+  migration id to stop at. For instance, running
+  `./manage.py upgradedb --seed 005` will skip migrations 000 to 005 but not
+  006.
 
 
 Conventions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,6 +50,23 @@ Options for upgradedb
   006.
 
 
+Configuration for comparedb
+---------------------------
+
+The `comparedb` command is available only for Postgres. It executes a few raw
+postgres shell commands which you might need to customize to add user
+credentials, encoding or specify database templates. This can be done through
+the `NASHVEGAS` dictionnary in your setting::
+
+    NASHVEGAS = {
+        'createdb': 'createdb -U postgres -T template0 -E UTF8',
+        'dropdb': 'dropdb -U postgres',
+        'pg_dump': 'pg_dump -U postgres',
+    }
+
+By default, nashvegas executes raw `createdb`, `dropdb` or `pg_dump` commands.
+
+
 Conventions
 -----------
 

--- a/nashvegas/management/commands/comparedb.py
+++ b/nashvegas/management/commands/comparedb.py
@@ -54,11 +54,11 @@ class Command(BaseCommand):
         orig = connections[DEFAULT_DB_ALIAS].settings_dict["NAME"]
         connections[DEFAULT_DB_ALIAS].close()
         connections[DEFAULT_DB_ALIAS].settings_dict["NAME"] = self.name
-        call_command("upgradedb", do_execute=True)
-        new_sql = Popen(["pg_dump", "-s", self.name], stdout=PIPE).stdout.readlines()
+        call_command("syncdb", interactive=False, verbosity=0)
+        new_sql = Popen(command.split() + ["-s", self.name],
+                        stdout=PIPE).stdout.readlines()
         connections[DEFAULT_DB_ALIAS].close()
         connections[DEFAULT_DB_ALIAS].settings_dict["NAME"] = orig
-
         self.teardown_database()
 
         print "Outputing diff between the two..."

--- a/nashvegas/management/commands/upgradedb.py
+++ b/nashvegas/management/commands/upgradedb.py
@@ -248,6 +248,8 @@ class Command(BaseCommand):
             stop_at = int(self.args[0])
         except ValueError:
             raise CommandError("Invalid --seed migration")
+        except IndexError:
+            raise CommandError("Usage: ./manage.py upgradedb --seed <stop_at>")
         migrations = [os.path.join(self.path, m) for m in self._filter_down(stop_at=stop_at)]
         for migration in migrations:
             m, created = Migration.objects.get_or_create(

--- a/nashvegas/management/commands/upgradedb.py
+++ b/nashvegas/management/commands/upgradedb.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 import traceback
 
@@ -18,6 +19,7 @@ from nashvegas.utils import get_sql_for_new_models
 
 
 sys.path.append("migrations")
+MIGRATION_NAME_RE = re.compile(r'(\d+)(.*)')
 
 
 class MigrationError(Exception):
@@ -76,10 +78,11 @@ class Command(BaseCommand):
             
             for script in in_directory:
                 name, ext = os.path.splitext(script)
-                try:
-                    number = int(name.split("_")[0])
-                except ValueError:
-                    raise MigrationError("Invalid migration file prefix (must begin with a number)")
+                match = MIGRATION_NAME_RE.match(name)
+                if match is None:
+                    raise MigrationError("Invalid migration file prefix "
+                                         "(must begin with a number)")
+                number = match.group(1)
                 if ext in [".sql", ".py"]:
                     scripts_in_directory.append((number, script))
             

--- a/nashvegas/management/commands/upgradedb.py
+++ b/nashvegas/management/commands/upgradedb.py
@@ -82,7 +82,7 @@ class Command(BaseCommand):
                 if match is None:
                     raise MigrationError("Invalid migration file prefix "
                                          "(must begin with a number)")
-                number = match.group(1)
+                number = int(match.group(1))
                 if ext in [".sql", ".py"]:
                     scripts_in_directory.append((number, script))
             


### PR DESCRIPTION
Sorry, it looks like I suck at branches... I started a new branch from brutasse:error-messages (previous pull request) instead of master. This request is for the last 3 commits, let me know if I should apply them to a fresh branch instead.

I've been playing with comparedb and I find this feature really nifty. I had 2 issues to get it to work:
- my local postgres install only accepts the 'postgres' user and won't create a UTF8 database if I don't pass it a specific template. I added an optional NASHVEGAS settings that lets the user specify his own commands with custom arguments. I've been hesitating between making this setting a command-line option but it's quite simple this way and falls back to simple `createdb`, `dropdb` and `pg_dump` calls if no setting is provided. (otherwise I'd have to map the management command's options with the postgres command, inevitably forgetting some use cases).
- Once I got comparedb working it wasn't outputting anything when I changed something in the models. Maybe I'm getting this wrong but I think `comparedb` should compare the current database with a fresh database created with `syncdb`. A switch to syncdb for the `_compare`-suffixed database properly shows missing indices, columns, tables and constraints.

Let me know what you think,
Bruno
