### PR TITLE
Allow Specification of the location of the migration directory

### DIFF
--- a/nashvegas/management/commands/upgradedb.py
+++ b/nashvegas/management/commands/upgradedb.py
@@ -45,13 +45,7 @@ class Command(BaseCommand):
                     default=DEFAULT_DB_ALIAS, help="Nominates a database to synchronize. "
             "Defaults to the \"default\" database."),
         make_option("-p", "--path", dest = "path",
-            default = os.path.join(
-                os.path.dirname(
-                    os.path.normpath(
-                        os.sys.modules[settings.SETTINGS_MODULE].__file__
-                    )
-                ), "migrations"
-            ),
+            default = None,
             help="The path to the database migration scripts."))
     help = "Upgrade database."
     
@@ -288,7 +282,19 @@ class Command(BaseCommand):
         self.do_seed = options.get("do_seed")
         self.args = args
         
-        self.path = options.get("path")
+        if options.get("path"):
+            self.path = options.get("path")
+        else:
+            default_path = os.path.join(
+                            os.path.dirname(
+                                os.path.normpath(
+                                    os.sys.modules[settings.SETTINGS_MODULE].__file__
+                                )
+                            ),
+                            "migrations"
+                        )
+            self.path = getattr(settings, "NASHVEGAS_MIGRATION_DIRECTORY", default_path)
+        
         self.verbosity = int(options.get("verbosity", 1))
         self.interactive = options.get("interactive")
         self.db = options.get("database", DEFAULT_DB_ALIAS)


### PR DESCRIPTION
Currently nashvegas assumes that the location of the migration directory is located alongside the file that the settings are from.

However this breaks when you use settings as a module like

```
settings
├── __init__.py
├── base.py
├── dev
│   ├── __init__.py
│   └── base.py
└── production
    ├── __init__.py
    ├── base.py
    └── gondor.py
```

This pull request adds a setting `NASHVEGAS_MIGRATION_DIRECTORY` that can be used to manually specify the location of the migrations directory. If this setting is missing it falls back to the previous method.
