### PR TITLE
Multidb support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-dist
 _build
 *.pyc
+/*.egg-info
+/dist
+/build

--- a/nashvegas/management/commands/syncdb.py
+++ b/nashvegas/management/commands/syncdb.py
@@ -6,7 +6,7 @@ class Command(SyncDBCommand):
     A custom syncdb command that asks you for confirmation
     before syncing the database.
     """
-    
+
     def handle_noargs(self, **options):
         if options.get("interactive"):
             confirm = raw_input("""
@@ -17,9 +17,8 @@ Are you sure you want to do this?
 Type 'yes' to continue, or 'no' to cancel: """)
         else:
             confirm = "yes"
-        
+
         if confirm == "yes":
             super(Command, self).handle_noargs(**options)
         else:
             print "Sync cancelled."
-

--- a/nashvegas/management/commands/upgradedb.py
+++ b/nashvegas/management/commands/upgradedb.py
@@ -318,7 +318,8 @@ class Command(BaseCommand):
             try:
 
                 for migration in migrations:
-                    created_models |= self._execute_migration(db, migration, show_traceback=show_traceback)
+                    migration_path = os.path.join(self.path, db, migration)
+                    created_models |= self._execute_migration(db, migration_path, show_traceback=show_traceback)
 
                 sys.stdout.write("Emitting post sync signal.\n")
                 emit_post_sync_signal(

--- a/nashvegas/management/commands/upgradedb.py
+++ b/nashvegas/management/commands/upgradedb.py
@@ -3,10 +3,11 @@ import re
 import sys
 import traceback
 
+from collections import defaultdict
 from optparse import make_option
 from subprocess import Popen, PIPE
 
-from django.db import connections, transaction, DEFAULT_DB_ALIAS
+from django.db import connections, router, transaction, DEFAULT_DB_ALIAS
 from django.db.models import get_model
 from django.conf import settings
 from django.core.management import call_command
@@ -38,60 +39,111 @@ class Command(BaseCommand):
         make_option("-c", "--create", action="store_true",
                     dest="do_create", default=False,
                     help="Generates sql for models that are installed but not in your database."),
+        make_option("--create-all", action="store_true",
+                    dest="do_create_all", default=False,
+                    help="Generates sql for models that are installed but not in your database."),
         make_option("-s", "--seed", action="store_true",
                     dest="do_seed", default=False,
                     help="Seed nashvegas with migrations that have previously been applied in another manner."),
         make_option("-d", "--database", action="store", dest="database",
-                    default=DEFAULT_DB_ALIAS, help="Nominates a database to synchronize. "
-                    "Defaults to the \"default\" database."),
+                    help="Nominates a database to synchronize."),
         make_option("-p", "--path", dest="path",
                     default=None,
                     help="The path to the database migration scripts."))
 
     help = "Upgrade database."
 
-    def _filter_down(self, stop_at=None):
+    def _get_capable_database(self):
+        for database in connections:
+            if router.allow_syncdb(database, Migration):
+                yield database
 
+    def _get_file_list(self, path, max_depth=1, cur_depth=0):
+        for name in os.listdir(path):
+            if name.startswith('.'):
+                continue
+
+            full_path = os.path.join(path, name)
+            if os.path.isdir(full_path):
+                if cur_depth == max_depth:
+                    continue
+
+                for result in self._get_file_list(full_path, max_depth, cur_depth + 1):
+                    yield result
+
+            else:
+                yield full_path
+
+    def _get_applied_migrations(self):
+        results = defaultdict(list)
+        already_applied = Migration.objects.all().order_by("migration_label")
+        for x in already_applied:
+            try:
+                version, database = x.scm_version.split(':')
+            except ValueError:
+                version, database = x.scm_version, DEFAULT_DB_ALIAS
+
+            results[database].append(x.migration_label)
+        return results
+
+    def _filter_down(self, stop_at=None):
         if stop_at is None:
             stop_at = float("inf")
 
-        applied = []
-        to_execute = []
-        scripts_in_directory = []
+        # database: [(number, full_path)]
+        possible_migrations = defaultdict(list)
+        # database: [full_path]
+        applied_migrations = self._get_applied_migrations()
+        # database: [full_path]
+        to_execute = defaultdict(list)
 
         try:
-            already_applied = Migration.objects.all().order_by("migration_label")
+            in_directory = sorted(self._get_file_list(self.path))
+        except OSError:
+            print "An error occurred while reading migrations from %r:" % self.path
+            traceback.print_exc()
+            return to_execute
 
-            for x in already_applied:
-                applied.append(x.migration_label)
+        # Iterate through our results and discover which migrations are actually runnable
+        for full_path in in_directory:
+            path, script = os.path.split(full_path)
+            name, ext = os.path.splitext(script)
 
-            in_directory = os.listdir(self.path)
-            in_directory = [migration for migration in in_directory if
-                            not migration.startswith(".")]
-            in_directory.sort()
-            applied.sort()
+            # the database component is default if this is in the root directory
+            # is <directory> if in a subdirectory
+            if path == self.path:
+                database = DEFAULT_DB_ALIAS
+            else:
+                database = os.path.split(path)[-1]
 
-            for script in in_directory:
-                name, ext = os.path.splitext(script)
-                match = MIGRATION_NAME_RE.match(name)
-                if match is None:
-                    raise MigrationError("Invalid migration file prefix "
-                                         "(must begin with a number)")
-                number = int(match.group(1))
-                if ext in [".sql", ".py"]:
-                    scripts_in_directory.append((number, script))
+            # filter by database if set
+            if self.db and database != self.db:
+                continue
 
-            for number, script in scripts_in_directory:
+            match = MIGRATION_NAME_RE.match(name)
+            if match is None:
+                raise MigrationError("Invalid migration file prefix %r "
+                                     "(must begin with a number)" % name)
+
+            number = int(match.group(1))
+            if ext in [".sql", ".py"]:
+                possible_migrations[database].append((number, full_path))
+            else:
+                raise MigrationError("Invalid migration file suffix %r "
+                                     "(unsupported file type)" % ext)
+
+        for database, scripts in possible_migrations.iteritems():
+            applied = applied_migrations[database]
+            pending = to_execute[database]
+            for number, script in scripts:
                 if script not in applied and number <= stop_at:
-                    to_execute.append(script)
-        except OSError, e:
-            print str(e)
+                    pending.append(script)
 
         return to_execute
 
     def _get_rev(self, fpath):
         """
-        Get an SCM verion number. Try svn and git.
+        Get an SCM version number. Try svn and git.
         """
         rev = None
 
@@ -113,6 +165,77 @@ class Command(BaseCommand):
                 pass
 
         return rev
+
+    def _get_current_migration_number(self, database):
+        try:
+            result = Migration.objects.using(database).order_by('-migration_label')[0]
+        except IndexError:
+            return 0
+        match = MIGRATION_NAME_RE.match(result.migration_level)
+        return int(match.group(1))
+
+    def _execute_migration(self, database, migration, show_traceback=True):
+        created_models = set()
+
+        with open(migration, "rb") as fp:
+            lines = fp.readlines()
+        content = "".join(lines)
+
+        if migration.endswith(".sql"):
+            # TODO: this should support proper comments
+            to_execute = "".join(
+                [l for l in lines if not l.startswith("### New Model: ")]
+            )
+            connection = connections[database]
+            cursor = connection.cursor()
+
+            sys.stdout.write("Executing %r on %r... " % (migration, database))
+
+            try:
+                cursor.execute(to_execute)
+                cursor.close()
+            except Exception:
+                sys.stdout.write("failed\n")
+                if show_traceback:
+                    traceback.print_exc()
+                raise MigrationError()
+            else:
+                sys.stdout.write("success\n")
+
+            for l in lines:
+                if l.startswith("### New Model: "):
+                    created_models.add(
+                        get_model(
+                            *l.replace("### New Model: ", "").strip().split(".")
+                        )
+                    )
+
+        elif migration.endswith(".py"):
+            # TODO: python files have no concept of active database
+            #       we should probably pass it to migrate()
+            sys.stdout.write("Executing %s... " % migration)
+
+            module = {}
+            execfile(migration, {}, module)
+
+            if "migrate" in module and callable(module["migrate"]):
+                try:
+                    module["migrate"]()
+                except Exception:
+                    sys.stdout.write("failed\n")
+                    if show_traceback:
+                        traceback.print_exc()
+                    raise MigrationError()
+                else:
+                    sys.stdout.write("success\n")
+
+        Migration.objects.using(database).create(
+            migration_label=os.path.split(migration)[-1],
+            content=content,
+            scm_version=self._get_rev(migration),
+        )
+
+        return created_models
 
     def init_nashvegas(self):
         # Copied from line 35 of django.core.management.commands.syncdb
@@ -136,107 +259,94 @@ class Command(BaseCommand):
                     raise
 
         # @@@ make cleaner / check explicitly for model instead of looping over and doing string comparisons
-        connection = connections[self.db]
-        cursor = connection.cursor()
-        all_new = get_sql_for_new_models(using=self.db)
-        for s in all_new:
-            if "nashvegas_migration" in s:
-                cursor.execute(s)
-                transaction.commit_unless_managed(using=self.db)
-                return
+        for database in self._get_capable_database():
+            connection = connections[database]
+            cursor = connection.cursor()
+            all_new = get_sql_for_new_models(['nashvegas'], using=database)
+            for lines in all_new:
+                to_execute = "\n".join(
+                    [l for l in lines.split("\n") if not l.startswith("### New Model: ")]
+                )
+                if not to_execute:
+                    continue
+                cursor.execute(to_execute)
+                transaction.commit_unless_managed(using=database)
 
-    def create_migrations(self):
-        statements = get_sql_for_new_models(self.args, using=self.db)
+    def create_all_migrations(self):
+        for database in self._get_capable_database():
+            statements = get_sql_for_new_models(using=database)
+            if len(statements) == 0:
+                continue
+
+            number = self._get_current_migration_number(database)
+
+            db_path = os.path.join(self.path, database)
+            if not os.path.exists(db_path):
+                os.makedirs(db_path)
+
+            path = os.path.join(db_path, '%s.sql' % (str(number + 1).zfill(4),))
+            if os.path.exists(path):
+                raise CommandError("Unable to create %r: File already exists" % path)
+
+            with open(path, 'w') as fp:
+                for s in statements:
+                    fp.write(s + '\n')
+
+            print "Created new migration: %r" % path
+
+    def create_migrations(self, database):
+        statements = get_sql_for_new_models(self.args, using=database)
         if len(statements) > 0:
             for s in statements:
                 print s
 
-    @transaction.commit_manually
-    def execute_migrations(self, show_traceback=False):
-        migrations = self._filter_down()
+    def execute_migrations(self, show_traceback=True):
+        all_migrations = self._filter_down()
 
-        if not len(migrations):
+        if not len(all_migrations):
             sys.stdout.write("There are no migrations to apply.\n")
 
         created_models = set()
 
-        try:
-            for migration in migrations:
-                migration_path = os.path.join(self.path, migration)
-                fp = open(migration_path, "rb")
-                lines = fp.readlines()
-                fp.close()
-                content = "".join(lines)
+        for db, migrations in all_migrations.iteritems():
+            connection = connections[db]
 
-                if migration_path.endswith(".sql"):
-                    to_execute = "".join(
-                        [l for l in lines if not l.startswith("### New Model: ")]
-                    )
-                    connection = connections[self.db]
-                    cursor = connection.cursor()
+            # init connection
+            cursor = connection.cursor()
+            cursor.close()
 
-                    sys.stdout.write("Executing %s... " % migration)
+            # enter transaction management
+            transaction.enter_transaction_management(using=db)
+            transaction.managed(True, using=db)
 
-                    try:
-                        cursor.execute(to_execute)
-                        cursor.close()
-                    except Exception:
-                        sys.stdout.write("failed\n")
-                        if show_traceback:
-                            traceback.print_exc()
-                        raise MigrationError()
-                    else:
-                        sys.stdout.write("success\n")
+            try:
 
-                    for l in lines:
-                        if l.startswith("### New Model: "):
-                            created_models.add(
-                                get_model(
-                                    *l.replace("### New Model: ", "").strip().split(".")
-                                )
-                            )
-                elif migration_path.endswith(".py"):
-                    sys.stdout.write("Executing %s... " % migration)
+                for migration in migrations:
+                    created_models |= self._execute_migration(db, migration, show_traceback=show_traceback)
 
-                    module = {}
-                    execfile(migration_path, {}, module)
-
-                    if "migrate" in module and callable(module["migrate"]):
-                        try:
-                            module["migrate"]()
-                        except Exception:
-                            sys.stdout.write("failed\n")
-                            if show_traceback:
-                                traceback.print_exc()
-                            raise MigrationError()
-                        else:
-                            sys.stdout.write("success\n")
-
-                Migration.objects.create(
-                    migration_label=migration,
-                    content=content,
-                    scm_version=self._get_rev(migration_path)
+                sys.stdout.write("Emitting post sync signal.\n")
+                emit_post_sync_signal(
+                    created_models=created_models,
+                    verbosity=self.verbosity,
+                    interactive=self.interactive,
+                    db=db,
                 )
-            sys.stdout.write("Emitting post sync signal.\n")
-            emit_post_sync_signal(
-                created_models,
-                self.verbosity,
-                self.interactive,
-                self.db
-            )
-            sys.stdout.write("Running loaddata for initial_data fixtures.\n")
-            call_command(
-                "loaddata",
-                "initial_data",
-                verbosity=self.verbosity,
-                database=self.db
-            )
-        except Exception:
-            transaction.rollback(using=self.db)
-            sys.stdout.write("Rolled back all migrations.\n")
-            raise
-        else:
-            transaction.commit(using=self.db)
+
+                sys.stdout.write("Running loaddata for initial_data fixtures.\n")
+                call_command(
+                    "loaddata",
+                    "initial_data",
+                    verbosity=self.verbosity,
+                    database=db,
+                )
+            except Exception:
+                transaction.rollback(using=db)
+                sys.stdout.write("Rolled back all migrations on %r.\n" % db)
+                raise
+            else:
+                transaction.commit(using=db)
+            finally:
+                transaction.leave_transaction_management(using=db)
 
     def seed_migrations(self, stop_at=None):
         # @@@ the command-line interface needs to be re-thinked
@@ -280,6 +390,7 @@ class Command(BaseCommand):
         self.do_list = options.get("do_list")
         self.do_execute = options.get("do_execute")
         self.do_create = options.get("do_create")
+        self.do_create_all = options.get("do_create_all")
         self.do_seed = options.get("do_seed")
         self.args = args
 
@@ -298,15 +409,24 @@ class Command(BaseCommand):
 
         self.verbosity = int(options.get("verbosity", 1))
         self.interactive = options.get("interactive")
-        self.db = options.get("database", DEFAULT_DB_ALIAS)
+        self.db = options.get("database")
+
+        # We only use the default alias in creation scenarios (upgrades default to all databases)
+        if self.do_create and not self.db:
+            self.db = DEFAULT_DB_ALIAS
+
+        if self.do_create and self.do_create_all:
+            raise CommandError("You cannot combine --create and --create-all")
 
         self.init_nashvegas()
 
-        if self.do_create:
-            self.create_migrations()
+        if self.do_create_all:
+            self.create_all_migrations()
+        elif self.do_create:
+            self.create_migrations(self.db)
 
         if self.do_execute:
-            self.execute_migrations(show_traceback=True)
+            self.execute_migrations()
 
         if self.do_list:
             self.list_migrations()

--- a/nashvegas/management/commands/upgradedb.py
+++ b/nashvegas/management/commands/upgradedb.py
@@ -367,7 +367,7 @@ class Command(BaseCommand):
                 print m.migration_label, "was already applied."
 
     def list_migrations(self):
-        all_migrations = list(self._filter_down())
+        all_migrations = self._filter_down()
         if len(all_migrations) == 0:
             print "There are no migrations to apply."
             return

--- a/nashvegas/models.py
+++ b/nashvegas/models.py
@@ -4,11 +4,11 @@ from django.db import models
 
 
 class Migration(models.Model):
-    
+
     migration_label = models.CharField(max_length=200)
     date_created = models.DateTimeField(default=datetime.now)
     content = models.TextField()
     scm_version = models.CharField(max_length=50, null=True, blank=True)
-    
+
     def __unicode__(self):
         return unicode("%s [%s]" % (self.migration_label, self.scm_version))

--- a/nashvegas/utils.py
+++ b/nashvegas/utils.py
@@ -4,30 +4,31 @@ from django.db import connections, router, models, DEFAULT_DB_ALIAS
 from django.utils.datastructures import SortedDict
 
 
-def get_sql_for_new_models(apps=None):
+def get_sql_for_new_models(apps=None, using=DEFAULT_DB_ALIAS):
     """
     Unashamedly copied and tweaked from django.core.management.commands.syncdb
     """
-    connection = connections[DEFAULT_DB_ALIAS]
-    
+    connection = connections[using]
+
     # Get a list of already installed *models* so that references work right.
     tables = connection.introspection.table_names()
     seen_models = connection.introspection.installed_models(tables)
     created_models = set()
     pending_references = {}
-    
+
     if apps:
         apps = [models.get_app(a) for a in apps]
     else:
         apps = models.get_apps()
-    
+
     # Build the manifest of apps and models that are to be synchronized
     all_models = [
         (app.__name__.split('.')[-2],
             [m for m in models.get_models(app, include_auto_created=True)
-            if router.allow_syncdb(DEFAULT_DB_ALIAS, m)])
+            if router.allow_syncdb(using, m)])
         for app in apps
     ]
+
     def model_installed(model):
         opts = model._meta
         converter = connection.introspection.table_name_converter
@@ -37,12 +38,12 @@ def get_sql_for_new_models(apps=None):
             converter(opts.auto_created._meta.db_table) in tables
         )
         return not (db_table_in or auto_create_in)
-    
+
     manifest = SortedDict(
         (app_name, filter(model_installed, model_list))
         for app_name, model_list in all_models
     )
-    
+
     statements = []
     sql = None
     for app_name, model_list in manifest.items():
@@ -53,14 +54,14 @@ def get_sql_for_new_models(apps=None):
                 no_style(),
                 seen_models
             )
-            
+
             seen_models.add(model)
             created_models.add(model)
             statements.append("### New Model: %s.%s" % (
                 app_name,
                 str(model).replace("'>", "").split(".")[-1]
             ))
-            
+
             for refto, refs in references.items():
                 pending_references.setdefault(refto, []).extend(refs)
                 if refto in seen_models:
@@ -71,7 +72,7 @@ def get_sql_for_new_models(apps=None):
                             pending_references
                         )
                     )
-            
+
             sql.extend(
                 connection.creation.sql_for_pending_references(
                     model,
@@ -80,7 +81,7 @@ def get_sql_for_new_models(apps=None):
                 )
             )
             statements.extend(sql)
-    
+
     custom_sql = None
     for app_name, model_list in manifest.items():
         for model in model_list:
@@ -90,10 +91,10 @@ def get_sql_for_new_models(apps=None):
                     no_style(),
                     connection
                 )
-                
+
                 if custom_sql:
                     statements.extend(custom_sql)
-    
+
     index_sql = None
     for app_name, model_list in manifest.items():
         for model in model_list:
@@ -102,8 +103,8 @@ def get_sql_for_new_models(apps=None):
                     model,
                     no_style()
                 )
-                
+
                 if index_sql:
                     statements.extend(index_sql)
-    
+
     return statements


### PR DESCRIPTION
(This requires #32, and the diff actually will show part of #32 until that is merged in)

Add full multi-db support via --create-all and --execute

This commit does several things:
- Migrations can now be read as path/`database`/`migration`.
- Allowed migration databases are now determined by the router, and nashvegas gets created
  on all capable connections to store state for that connection.
- A new flag on upgradedb, --create-all was added. This attempt will dump creation migrations
  in `path` for all databases.
- The --execute flag will now run against all databases.
- The comparedb command now supports the --database argument.

I'd still like to make more improvements, such as bringing in a more South-like interface (e.g. syncdb --migrate, and migrate), as well as incorporate support for the test suite.
