### PR TITLE
Ignore .pyc files by default in migrations

### DIFF
--- a/nashvegas/management/commands/upgradedb.py
+++ b/nashvegas/management/commands/upgradedb.py
@@ -135,9 +135,6 @@ class Command(BaseCommand):
             number = int(match.group(1))
             if ext in [".sql", ".py"]:
                 possible_migrations[database].append((number, full_path))
-            else:
-                raise MigrationError("Invalid migration file suffix %r "
-                                     "(unsupported file type)" % ext)
         
         for database, scripts in possible_migrations.iteritems():
             applied = applied_migrations[database]


### PR DESCRIPTION
I deployed packaged django projects and for some reason I get .pyc files in my migrations directory.

This ignores them by default, although I'm not sure nashvegas should cry that loud when an extension isn't recognized. A RuntimeWarning is probably enough…
