### PR TITLE
Change migrations to be transactional

### DIFF
--- a/nashvegas/management/commands/upgradedb.py
+++ b/nashvegas/management/commands/upgradedb.py
@@ -23,6 +23,22 @@ sys.path.append("migrations")
 MIGRATION_NAME_RE = re.compile(r"(\d+)(.*)")
 
 
+class Transactional(object):
+    def __enter__(self):
+        for db in connections:
+            # enter transaction management
+            transaction.enter_transaction_management(using=db)
+            transaction.managed(True, using=db)
+    
+    def __exit__(self, exc_type, exc_value, traceback):
+        for db in connections:
+            if exc_type:
+                transaction.rollback(using=db)
+            else:
+                transaction.commit(using=db)
+            transaction.leave_transaction_management(using=db)
+
+
 class MigrationError(Exception):
     pass
 
@@ -326,48 +342,34 @@ class Command(BaseCommand):
         if not len(all_migrations):
             sys.stdout.write("There are no migrations to apply.\n")
         
-        created_models = set()
-        
         for db, migrations in all_migrations.iteritems():
             connection = connections[db]
             
             # init connection
             cursor = connection.cursor()
             cursor.close()
-            
-            # enter transaction management
-            transaction.enter_transaction_management(using=db)
-            transaction.managed(True, using=db)
-            
-            try:
-                for migration in migrations:
-                    # legacy migrations were not located within a child directory
-                    migration_path = self._get_migration_path(db, migration)
-                    created_models |= self._execute_migration(db, migration_path, show_traceback=show_traceback)
+                        
+            for migration in migrations:
+                migration_path = self._get_migration_path(db, migration)
                 
-                sys.stdout.write("Emitting post sync signal.\n")
-                emit_post_sync_signal(
-                    created_models=created_models,
-                    verbosity=self.verbosity,
-                    interactive=self.interactive,
-                    db=db,
-                )
-                
-                sys.stdout.write("Running loaddata for initial_data fixtures.\n")
-                call_command(
-                    "loaddata",
-                    "initial_data",
-                    verbosity=self.verbosity,
-                    database=db,
-                )
-            except Exception:
-                transaction.rollback(using=db)
-                sys.stdout.write("Rolled back all migrations on %r.\n" % db)
-                raise
-            else:
-                transaction.commit(using=db)
-            finally:
-                transaction.leave_transaction_management(using=db)
+                with Transactional():
+                    sys.stdout.write("Executing migration %r on %r.\n" % (migration, db))
+                    created_models = self._execute_migration(db, migration_path, show_traceback=show_traceback)
+
+                    emit_post_sync_signal(
+                        created_models=created_models,
+                        verbosity=self.verbosity,
+                        interactive=self.interactive,
+                        db=db,
+                    )
+            
+            sys.stdout.write("Running loaddata for initial_data fixtures on %r.\n" % db)
+            call_command(
+                "loaddata",
+                "initial_data",
+                verbosity=self.verbosity,
+                database=db,
+            )
     
     def seed_migrations(self, stop_at=None):
         # @@@ the command-line interface needs to be re-thinked


### PR DESCRIPTION
This corrects some weird behavior we've seen by only running transactions on the current database. I know we briefly talked about transactions, but I want to confirm there are actual issues where migration A should rely on migration B, as that doesnt really seem like great design.

Specifically, each migration is run in its own transaction, and then syncdb is run, all within the single transaction. THis is committed and the next migration is run. Once all migrations are run on a database, it will run the loaddata command.
