### PR TITLE
Improve SyncDB

### DIFF
--- a/nashvegas/management/commands/syncdb.py
+++ b/nashvegas/management/commands/syncdb.py
@@ -4,4 +4,10 @@ from django.core.management.commands.syncdb import Command as SyncDBCommand
 
 class Command(SyncDBCommand):
     def handle_noargs(self, **options):
-        call_command("upgradedb", do_execute=True)
+        # Run migrations first
+        # {'load_initial_data': False, 'verbosity': 1, 'interactive': False, 'database': 'default'}
+        call_command("upgradedb", do_execute=True, database=options.get('database'), verbosity=options.get('verbosity'))
+
+        # Follow up with a syncdb on anything that wasnt included in migrations
+        # (this catches things like test-only models)
+        super(Command, self).handle_noargs(**options)

--- a/nashvegas/management/commands/upgradedb.py
+++ b/nashvegas/management/commands/upgradedb.py
@@ -358,13 +358,14 @@ class Command(BaseCommand):
                         db=db,
                     )
             
-            sys.stdout.write("Running loaddata for initial_data fixtures on %r.\n" % db)
-            call_command(
-                "loaddata",
-                "initial_data",
-                verbosity=self.verbosity,
-                database=db,
-            )
+            if self.load_initial_data:
+                sys.stdout.write("Running loaddata for initial_data fixtures on %r.\n" % db)
+                call_command(
+                    "loaddata",
+                    "initial_data",
+                    verbosity=self.verbosity,
+                    database=db,
+                )
     
     def seed_migrations(self, stop_at=None):
         # @@@ the command-line interface needs to be re-thinked
@@ -420,6 +421,7 @@ class Command(BaseCommand):
         self.do_create = options.get("do_create")
         self.do_create_all = options.get("do_create_all")
         self.do_seed = options.get("do_seed")
+        self.load_initial_data = options.get("load_initial_data", True)
         self.args = args
         
         if options.get("path"):


### PR DESCRIPTION
Including:
- Support --database option
- Support --verbosity option
- Call syncdb after upgrade is run to ensure things like custom
  models within the test suite still get created.

I'm not really sure about the last change in the list. It solved our problems but it's not the greatest solution.
