### PR TITLE
comparedb improvements (ignoring, more context, error handling)

### DIFF
--- a/nashvegas/management/commands/comparedb.py
+++ b/nashvegas/management/commands/comparedb.py
@@ -29,6 +29,11 @@ class Command(BaseCommand):
                     default=DEFAULT_DB_ALIAS,
                     help="Nominates a database to synchronize. "
                          "Defaults to the \"default\" database."),
+        make_option("-l", "--lines-of-context",
+                    action="store",
+                    dest="lines",
+                    default=10,
+                    help="Show this amount of context."),
     )
     help = "Checks for schema differences."
     
@@ -51,6 +56,7 @@ class Command(BaseCommand):
         self.db = options.get("database", DEFAULT_DB_ALIAS)
         self.current_name = connections[self.db].settings_dict["NAME"]
         self.compare_name = options.get("db_name")
+        self.lines = options.get("lines")
 
         if not self.compare_name:
             self.compare_name = "%s_compare" % self.current_name
@@ -79,4 +85,5 @@ class Command(BaseCommand):
         
         print "Outputing diff between the two..."
         print "".join(difflib.unified_diff(normalize_sql(current_sql),
-                                           normalize_sql(new_sql)))
+                                           normalize_sql(new_sql),
+                                           n=int(self.lines)))

--- a/nashvegas/management/commands/comparedb.py
+++ b/nashvegas/management/commands/comparedb.py
@@ -11,9 +11,10 @@ from django.core.management.base import BaseCommand
 
 NASHVEGAS = getattr(settings, "NASHVEGAS", {})
 
+
 def ignorable_sql(line, level):
     if level == 0:
-        return False # ignore nothing
+        return False  # ignore nothing
 
     # level 1 = ignore comments
     if level > 0 and line.lstrip().startswith("--"):
@@ -25,9 +26,11 @@ def ignorable_sql(line, level):
 
     return False
 
+
 def normalize_sql(lines, level=1):
     """ perform simple normalization: remove comments """
     return [line for line in lines if not ignorable_sql(line, level)]
+
 
 class Command(BaseCommand):
     

--- a/nashvegas/management/commands/comparedb.py
+++ b/nashvegas/management/commands/comparedb.py
@@ -74,14 +74,16 @@ class Command(BaseCommand):
         self.setup_database()
         connections[self.db].close()
         connections[self.db].settings_dict["NAME"] = self.compare_name
-        call_command("syncdb", interactive=False, verbosity=0)
-        new_sql = Popen(
-            command.format(dbname=self.compare_name).split(),
-            stdout=PIPE
-        ).stdout.readlines()
-        connections[self.db].close()
-        connections[self.db].settings_dict["NAME"] = self.current_name
-        self.teardown_database()
+        try:
+            call_command("syncdb", interactive=False, verbosity=0)
+            new_sql = Popen(
+                command.format(dbname=self.compare_name).split(),
+                stdout=PIPE
+            ).stdout.readlines()
+        finally:
+            connections[self.db].close()
+            connections[self.db].settings_dict["NAME"] = self.current_name
+            self.teardown_database()
         
         print "Outputing diff between the two..."
         print "".join(difflib.unified_diff(normalize_sql(current_sql),

--- a/nashvegas/management/commands/comparedb.py
+++ b/nashvegas/management/commands/comparedb.py
@@ -11,6 +11,9 @@ from django.core.management.base import BaseCommand
 
 NASHVEGAS = getattr(settings, "NASHVEGAS", {})
 
+def normalize_sql(lines):
+    """ perform simple normalization: remove comments """
+    return [line for line in lines if not line.startswith("--")]
 
 class Command(BaseCommand):
     
@@ -48,6 +51,7 @@ class Command(BaseCommand):
         self.db = options.get("database", DEFAULT_DB_ALIAS)
         self.current_name = connections[self.db].settings_dict["NAME"]
         self.compare_name = options.get("db_name")
+
         if not self.compare_name:
             self.compare_name = "%s_compare" % self.current_name
         
@@ -74,4 +78,5 @@ class Command(BaseCommand):
         self.teardown_database()
         
         print "Outputing diff between the two..."
-        print "".join(difflib.unified_diff(current_sql, new_sql))
+        print "".join(difflib.unified_diff(normalize_sql(current_sql),
+                                           normalize_sql(new_sql)))

--- a/nashvegas/management/commands/comparedb.py
+++ b/nashvegas/management/commands/comparedb.py
@@ -96,7 +96,7 @@ class Command(BaseCommand):
         connections[self.db].close()
         connections[self.db].settings_dict["NAME"] = self.compare_name
         try:
-            call_command("syncdb", interactive=False, verbosity=0)
+            call_command("syncdb", interactive=False, verbosity=0, migrations=False)
             new_sql = Popen(
                 command.format(dbname=self.compare_name).split(),
                 stdout=PIPE

--- a/nashvegas/management/commands/syncdb.py
+++ b/nashvegas/management/commands/syncdb.py
@@ -2,6 +2,7 @@ from django.core.management import call_command
 from django.core.management.commands.syncdb import Command as SyncDBCommand
 from optparse import make_option
 
+
 class Command(SyncDBCommand):
     option_list = SyncDBCommand.option_list + (
         make_option('--skip-migrations',
@@ -10,6 +11,7 @@ class Command(SyncDBCommand):
                     default=True,
                     help='Skip nashvegas migrations, do traditional syncdb'),
     )
+
     def handle_noargs(self, **options):
         # Run migrations first
         if options.get("database"):
@@ -17,7 +19,6 @@ class Command(SyncDBCommand):
         else:
             databases = None
         migrations = options.get('migrations')
-        
 
         if migrations:
             call_command(
@@ -27,7 +28,7 @@ class Command(SyncDBCommand):
                 interactive=options.get("interactive"),
                 verbosity=options.get("verbosity"),
             )
-        
+
         # Follow up with a syncdb on anything that wasnt included in migrations
         # (this catches things like test-only models)
         super(Command, self).handle_noargs(**options)

--- a/nashvegas/management/commands/syncdb.py
+++ b/nashvegas/management/commands/syncdb.py
@@ -1,22 +1,32 @@
 from django.core.management import call_command
 from django.core.management.commands.syncdb import Command as SyncDBCommand
-
+from optparse import make_option
 
 class Command(SyncDBCommand):
+    option_list = SyncDBCommand.option_list + (
+        make_option('--skip-migrations',
+                    action='store_false',
+                    dest='migrations',
+                    default=True,
+                    help='Skip nashvegas migrations, do traditional syncdb'),
+    )
     def handle_noargs(self, **options):
         # Run migrations first
         if options.get("database"):
             databases = [options.get("database")]
         else:
             databases = None
+        migrations = options.get('migrations')
         
-        call_command(
-            "upgradedb",
-            do_execute=True,
-            databases=databases,
-            interactive=options.get("interactive"),
-            verbosity=options.get("verbosity"),
-        )
+
+        if migrations:
+            call_command(
+                "upgradedb",
+                do_execute=True,
+                databases=databases,
+                interactive=options.get("interactive"),
+                verbosity=options.get("verbosity"),
+            )
         
         # Follow up with a syncdb on anything that wasnt included in migrations
         # (this catches things like test-only models)


### PR DESCRIPTION
I've noticed a couple of issues with nashvegas (comparedb):
- it doesn't always provide enough content to find which table has changed (and it's not always trivial to figure out what the table name should be) -> added a "-l" option to provide lines of context
- it provides noise by comparing irrelevant data such as comments and "ADD CONSTRAINT" lines. These can be selectively ignored using a "-i <level>" flag
- if something is wrong with a migration (e.g. an empty .sql file that I was about to write), comparedb no longer works. But more annoying, the compare database is not removed; fixed this.

Additionally, syncdb is make do work again somewhat using the --skip-migrations flag. This allows comparedb to work (create new database+syncdb) if there are migrations (which cannot be applied before the real syncdb has taken place)
